### PR TITLE
tests: fix delayed GUI start

### DIFF
--- a/qubesinputproxy/tests.py
+++ b/qubesinputproxy/tests.py
@@ -440,7 +440,14 @@ class TC_00_InputProxy(ExtraTestCase):
         time.sleep(2)
         self.allow_service('qubes.InputMouse')
         # trigger GUI startup
-        self.vm.run("true", gui=True, wait=True)
+        try:
+            # R4.0+
+            p = self.loop.run_until_complete(
+                asyncio.create_subprocess_exec('qvm-start-gui', self.vm.name))
+            self.loop.run_until_complete(p.communicate())
+        except (FileNotFoundError, AttributeError):
+            # R3.2
+            self.vm.run("true", gui=True, wait=True)
         self.find_device_and_start_listener()
         self.emit_event('REL_X', 1)
         self.emit_event('REL_X', 1)


### PR DESCRIPTION
In R4.0+, vm.run(..., gui=True) does not start gui-daemon anymore.
qvm-start-gui needs to be called explicitly.
The test worked before only because vm.start(..., start_guid=False)
started the gui-daemon anyway - which was fixed recently.