### PR TITLE
Improve tests, update packaging

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,9 +2,14 @@
 all:
 	$(MAKE) -C src all
 
-install:
+install: install-vm install-dom0
+
+install-vm:
 	$(MAKE) -C src install
-	$(MAKE) -C qubes-rpc install
+	$(MAKE) -C qubes-rpc install-vm
+
+install-dom0:
+	$(MAKE) -C qubes-rpc install-dom0
 	python3 setup.py install -O1 --root $(DESTDIR)
 
 clean:

--- a/debian/patches/01_install_systemd_service.diff
+++ b/debian/patches/01_install_systemd_service.diff
@@ -1,7 +1,9 @@
 --- a/qubes-rpc/Makefile
 +++ b/qubes-rpc/Makefile
-@@ -1,11 +1,11 @@
- install:
+@@ -9,13 +9,13 @@
+ 		$(DESTDIR)/etc/qubes-rpc/policy/qubes.InputTablet
+ 
+ install-vm:
 -	install -d $(DESTDIR)/usr/lib/systemd/system
 +	install -d $(DESTDIR)/lib/systemd/system
  	install -m 0644 \

--- a/debian/qubes-input-proxy-receiver.install
+++ b/debian/qubes-input-proxy-receiver.install
@@ -3,4 +3,4 @@
 /etc/qubes-rpc/qubes.InputKeyboard
 /etc/qubes-rpc/qubes.InputTablet
 /lib/udev/rules.d/90-qubes-uinput.rules
-
+/lib/modules-load.d/qubes-uinput.conf

--- a/debian/rules
+++ b/debian/rules
@@ -27,6 +27,10 @@ include /usr/share/dpkg/default.mk
 #	dh_auto_configure -- \
 #	-DCMAKE_LIBRARY_PATH=$(DEB_HOST_MULTIARCH)
 
+override_dh_auto_install:
+	make install-vm DESTDIR=$(PWD)/debian/tmp
 
+override_dh_missing:
+	dh_missing --fail-missing
 
 

--- a/qubes-rpc/Makefile
+++ b/qubes-rpc/Makefile
@@ -1,4 +1,14 @@
-install:
+install: install-vm install-dom0
+
+install-dom0:
+	install -m 0664 -D qubes.InputMouse.policy \
+		$(DESTDIR)/etc/qubes-rpc/policy/qubes.InputMouse
+	install -m 0664 -D qubes.InputKeyboard.policy \
+		$(DESTDIR)/etc/qubes-rpc/policy/qubes.InputKeyboard
+	install -m 0664 -D qubes.InputTablet.policy \
+		$(DESTDIR)/etc/qubes-rpc/policy/qubes.InputTablet
+
+install-vm:
 	install -d $(DESTDIR)/usr/lib/systemd/system
 	install -m 0644 \
 		qubes-input-sender-keyboard@.service \
@@ -17,12 +27,6 @@ install:
 	install qubes.InputMouse $(DESTDIR)/etc/qubes-rpc
 	install qubes.InputKeyboard $(DESTDIR)/etc/qubes-rpc
 	install qubes.InputTablet $(DESTDIR)/etc/qubes-rpc
-	install -m 0664 -D qubes.InputMouse.policy \
-		$(DESTDIR)/etc/qubes-rpc/policy/qubes.InputMouse
-	install -m 0664 -D qubes.InputKeyboard.policy \
-		$(DESTDIR)/etc/qubes-rpc/policy/qubes.InputKeyboard
-	install -m 0664 -D qubes.InputTablet.policy \
-		$(DESTDIR)/etc/qubes-rpc/policy/qubes.InputTablet
 	install -m 0755 -D qubes-input-trigger \
 		$(DESTDIR)/usr/bin/qubes-input-trigger
 	install -m 0644 -D qubes-input-trigger.desktop \

--- a/qubesinputproxy/tests.py
+++ b/qubesinputproxy/tests.py
@@ -447,7 +447,8 @@ class TC_00_InputProxy(ExtraTestCase):
             self.loop.run_until_complete(p.communicate())
         except (FileNotFoundError, AttributeError):
             # R3.2
-            self.vm.run("true", gui=True, wait=True)
+            pass
+        self.vm.run("true", gui=True, wait=True)
         self.find_device_and_start_listener()
         self.emit_event('REL_X', 1)
         self.emit_event('REL_X', 1)

--- a/rpm_spec/input-proxy.spec.in
+++ b/rpm_spec/input-proxy.spec.in
@@ -2,7 +2,7 @@ Name:		qubes-input-proxy
 Version:	@VERSION@
 Release:	1%{?dist}
 Obsoletes:	input-proxy
-Summary:	Simple input device proxy (receiver)
+Summary:	Simple input device proxy (dom0)
 
 Group:		System Environment/Daemons
 License:	GPLv2
@@ -12,6 +12,8 @@ BuildRequires:	gcc
 BuildRequires:	kernel-headers
 BuildRequires:	python%{python3_pkgversion}-setuptools
 BuildRequires:	python%{python3_pkgversion}-devel
+
+Requires: %{name}-receiver
 
 Source0: %{name}-%{version}.tar.gz
 
@@ -30,6 +32,16 @@ Simple input device proxy, which pass events from /dev/input/eventN device, to
 /dev/uintput. It uses stdin/stdout, so it suitable for use as Qubes RPC service.
 This package is sender part.
 
+%package receiver
+Summary:    Simple input device proxy (receiver)
+%{?systemd_requires}
+BuildRequires:  systemd
+
+%description receiver
+Simple input device proxy, which pass events from /dev/input/eventN device, to
+/dev/uintput. It uses stdin/stdout, so it suitable for use as Qubes RPC service.
+This package is sender part.
+
 %prep
 %setup -q
 
@@ -43,12 +55,6 @@ make install DESTDIR=%{buildroot}
 %files
 %doc README.md
 %defattr(-,root,root,-)
-/usr/bin/input-proxy-receiver
-/etc/qubes-rpc/qubes.InputMouse
-/etc/qubes-rpc/qubes.InputKeyboard
-/etc/qubes-rpc/qubes.InputTablet
-/lib/udev/rules.d/90-qubes-uinput.rules
-/lib/modules-load.d/qubes-uinput.conf
 %{python3_sitelib}/qubesinputproxy-*.egg-info/*
 %{python3_sitelib}/qubesinputproxy
 %attr(0664,root,qubes) %config(noreplace) /etc/qubes-rpc/policy/qubes.InputMouse
@@ -67,6 +73,16 @@ make install DESTDIR=%{buildroot}
 %{_unitdir}/qubes-input-sender-mouse@.service
 %{_unitdir}/qubes-input-sender-keyboard@.service
 %{_unitdir}/qubes-input-sender-keyboard-mouse@.service
+
+%files receiver
+%doc README.md
+%defattr(-,root,root,-)
+/usr/bin/input-proxy-receiver
+/etc/qubes-rpc/qubes.InputMouse
+/etc/qubes-rpc/qubes.InputKeyboard
+/etc/qubes-rpc/qubes.InputTablet
+/lib/udev/rules.d/90-qubes-uinput.rules
+/lib/modules-load.d/qubes-uinput.conf
 
 %changelog
 @CHANGELOG@


### PR DESCRIPTION
- fix `test_050_mouse_late_attach`
- rpm: split receiver into separate package (installable in a VM)
- debian: add missing files