### PR TITLE
Update sudo rules for new startup trigger mechanism

### DIFF
--- a/qubes-rpc/qubes-input-trigger
+++ b/qubes-rpc/qubes-input-trigger
@@ -72,8 +72,12 @@ def handle_service(service, action):
         print("Unknown action: %s" % action)
         sys.exit(1)
 
+    sudo = []
+    if os.getuid() != 0:
+        sudo = ["sudo"]
+
     subprocess.call(
-        ["sudo", "/bin/systemctl", "--no-block", systemctl_action, service])
+        sudo + ["/bin/systemctl", "--no-block", systemctl_action, service])
 
 
 def handle_event(input_dev, action, dom0):

--- a/qubes-rpc/qubes-input-trigger.sudoers
+++ b/qubes-rpc/qubes-input-trigger.sudoers
@@ -2,4 +2,7 @@
 # This is especially needed when qrexec policy is set to "ask", because it can
 # be allowed only when there is a way to ask the user.
 
-user ALL=(root) NOPASSWD:/bin/udevadm trigger --action=add --sysname-match=event[0-9]
+user ALL=(root) NOPASSWD:/bin/systemctl --no-block start qubes-input-sender-keyboard@event[0-9].service
+user ALL=(root) NOPASSWD:/bin/systemctl --no-block start qubes-input-sender-mouse@event[0-9].service
+user ALL=(root) NOPASSWD:/bin/systemctl --no-block start qubes-input-sender-tablet@event[0-9].service
+user ALL=(root) NOPASSWD:/bin/systemctl --no-block start qubes-input-sender-keyboard-mouse@event[0-9].service


### PR DESCRIPTION
Service is now started directly, instead of via udev.

Fixes QubesOS/qubes-issues#6160