### PR TITLE
Automatically detect dom0

### DIFF
--- a/qubes-rpc/qubes-input-sender
+++ b/qubes-rpc/qubes-input-sender
@@ -8,6 +8,10 @@ if [ -n "$SERVICE_RPC" ] && [ -n "$EVENT_FILE" ]; then
     if [ -e /usr/bin/qrexec-client-vm ]; then
         /usr/bin/qrexec-client-vm "$TARGET_DOMAIN" "$SERVICE_RPC" /usr/bin/input-proxy-sender "$EVENT_FILE"
     else
+        if [ "$TARGET_DOMAIN" = "dom0" ]; then
+            echo "Device $EVENT_FILE is already in dom0"
+            exit 0
+        fi
         /usr/bin/qrexec-client -d "$TARGET_DOMAIN" -l "/usr/bin/input-proxy-sender $EVENT_FILE" "DEFAULT:QUBESRPC $SERVICE_RPC dom0"
     fi
 else

--- a/qubes-rpc/qubes-input-trigger
+++ b/qubes-rpc/qubes-input-trigger
@@ -28,7 +28,8 @@ def get_args():
     parser.add_argument(
         "--dom0",
         required=False,
-        action="store_true"
+        action="store_true",
+        default=os.path.exists('/etc/qubes-release'),
     )
     return parser.parse_args()
 


### PR DESCRIPTION
qubes-input-trigger can be called with --dom0 option to adjust list of
devices it acts on. This option is correctly used on GUI VM startup, but
not when called from /etc/xdg/autostart/qubes-input-trigger.desktop
(which is the same in dom0 and VM). Fix this by automatically defaulting
to --dom0 if qubes-input-trigger is called in dom0.

Specifically, this will exclude virtual input devices that are passed
through from sys-usb already.