### PR TITLE
Add support for building Archlinux packages

### DIFF
--- a/Makefile.builder
+++ b/Makefile.builder
@@ -3,3 +3,5 @@ ifneq ($(filter $(DISTRIBUTION), debian qubuntu),)
 endif
 
 RPM_SPEC_FILES := rpm_spec/input-proxy.spec
+
+ARCH_BUILD_DIRS := archlinux

--- a/archlinux/PKGBUILD
+++ b/archlinux/PKGBUILD
@@ -1,0 +1,24 @@
+pkgname=qubes-input-proxy
+pkgver=`cat version`
+pkgrel=1
+pkgdesc="The Qubes service for proxying input devices"
+arch=("x86_64")
+url="http://qubes-os.org/"
+license=('GPL')
+depends=('sh' 'qubes-vm-core' 'usbutils')
+makedepends=(pkg-config make gcc)
+
+changelog=debian/changelog
+source=()
+md5sums=()
+
+build() {
+  cd ..
+  make clean
+  make all LIBDIR=/usr/lib USRLIBDIR=/usr/lib SYSLIBDIR=/usr/lib
+}
+
+package() {
+  cd ..
+  make install-vm DESTDIR=$pkgdir LIBDIR=/usr/lib USRLIBDIR=/usr/lib SYSLIBDIR=/usr/lib
+}

--- a/qubes-rpc/Makefile
+++ b/qubes-rpc/Makefile
@@ -1,5 +1,8 @@
 install: install-vm install-dom0
 
+LIBDIR ?= /lib
+USRLIBDIR ?= /usr/lib
+
 install-dom0:
 	install -m 0664 -D qubes.InputMouse.policy \
 		$(DESTDIR)/etc/qubes-rpc/policy/qubes.InputMouse
@@ -9,20 +12,20 @@ install-dom0:
 		$(DESTDIR)/etc/qubes-rpc/policy/qubes.InputTablet
 
 install-vm:
-	install -d $(DESTDIR)/usr/lib/systemd/system
+	install -d $(DESTDIR)$(USRLIBDIR)/systemd/system
 	install -m 0644 \
 		qubes-input-sender-keyboard@.service \
 		qubes-input-sender-keyboard-mouse@.service \
 		qubes-input-sender-mouse@.service \
 		qubes-input-sender-tablet@.service \
-		$(DESTDIR)/usr/lib/systemd/system
-	install -d $(DESTDIR)/lib/udev/rules.d
+		$(DESTDIR)$(USRLIBDIR)/systemd/system
+	install -d $(DESTDIR)$(LIBDIR)/udev/rules.d
 	install -m 0644 qubes-input-proxy.rules \
-		$(DESTDIR)/lib/udev/rules.d/90-qubes-input-proxy.rules
+		$(DESTDIR)$(LIBDIR)/udev/rules.d/90-qubes-input-proxy.rules
 	install -m 0644 qubes-uinput.rules \
-		$(DESTDIR)/lib/udev/rules.d/90-qubes-uinput.rules
+		$(DESTDIR)$(LIBDIR)/udev/rules.d/90-qubes-uinput.rules
 	install -m 0644 -D qubes-uinput.modules \
-		$(DESTDIR)/lib/modules-load.d/qubes-uinput.conf
+		$(DESTDIR)$(LIBDIR)/modules-load.d/qubes-uinput.conf
 	install -d $(DESTDIR)/etc/qubes-rpc
 	install qubes.InputMouse $(DESTDIR)/etc/qubes-rpc
 	install qubes.InputKeyboard $(DESTDIR)/etc/qubes-rpc


### PR DESCRIPTION
I've tried to do this with the minimum of refactoring. It might have been slightly cleaner if I had split apart `make all` and made a dedicated `make build` command that doesn't `install` things, I was worried that I might break some of the packaging for the other distributions...