### PR TITLE
tests: Switch to own fork of python-uinput

### DIFF
--- a/qubesinputproxy/tests.py
+++ b/qubesinputproxy/tests.py
@@ -81,7 +81,7 @@ class TC_00_InputProxy(ExtraTestCase):
             self.vm.start(start_guid=False)
             if self.vm.run("python3 -c 'import uinput'", wait=True, gui=False) != 0:
                 # If uinput module not installed, try to install it with pip
-                p = self.vm.run("pip3 install python-uinput 2>&1", passio_popen=True,
+                p = self.vm.run("pip3 install git+https://github.com/marmarek/python-uinput@py311 2>&1", passio_popen=True,
                     user="root", gui=False)
                 (stdout, _) = p.communicate()
                 if p.returncode != 0:


### PR DESCRIPTION
The upstream repository is not maintained anymore, switch to own fork
that has py3.11 patches on top.

Fixes QubesOS/qubes-issues#7833