### PR TITLE
exclude qubes virtual input device created by the gui agent

### DIFF
--- a/qubes-rpc/qubes-input-proxy.rules
+++ b/qubes-rpc/qubes-input-proxy.rules
@@ -5,6 +5,12 @@ ENV{ID_BUS}=="i8042", GOTO="qubes_input_proxy_end"
 ENV{ID_PATH}=="acpi-*", GOTO="qubes_input_proxy_end"
 ENV{ID_PATH}=="platform-*", GOTO="qubes_input_proxy_end"
 
+# tag virtual input device so it can be identified when qubes-input-trigger is launched by /etc/xdg/autostart/qubes-input-trigger.desktop
+ATTRS{name}=="Qubes Virtual Input Device", TAG="qubes-virtual-input-device"
+
+# skip virtual input device created by gui agent
+ATTRS{name}=="Qubes Virtual Input Device", GOTO="qubes_input_proxy_end"
+
 KERNEL=="event*", ACTION=="add", RUN+="/usr/bin/qubes-input-trigger --event %k --action add"
 KERNEL=="event*", ACTION=="remove", RUN+="/usr/bin/qubes-input-trigger --event %k --action remove"
 

--- a/qubes-rpc/qubes-input-trigger
+++ b/qubes-rpc/qubes-input-trigger
@@ -109,6 +109,9 @@ def handle_event(input_dev, action, dom0):
                     return
                 if '/devices/virtual/' in udevreturn and dom0:
                     return
+                # exclude qubes virtual input device created by gui agent
+                if 'TAGS=:qubes-virtual-input-device:' in udevreturn:
+                    return
                 # We exclude in sys-usb ID_PATH=acpi-* and ID_PATH=platform-*
                 # which can correspond to power-switch buttons. By default, HVM
                 # exposes some so there is no point for adding input devices


### PR DESCRIPTION
I will be submitting a pull request for https://github.com/QubesOS/qubes-gui-agent-linux as well. The pull request for the gui agent implements virtual input device creation allowing for the use of kloak. When the input device is created by the gui agent on qube startup, notifications for qubes.InputMouse and qubes.InputKeyboard being denied will be triggered. The virtual input device still works, but it is a little jarring. This pull request resolves that issue by excluding the virtual input device from qubes-input-trigger.