### PR TITLE
input-proxy-sender: Add comment re: masking LED events

### DIFF
--- a/src/input-proxy-sender.c
+++ b/src/input-proxy-sender.c
@@ -177,6 +177,12 @@ int main(int argc, char **argv) {
 
     /* TODO: produce synthetic EV_REP initial events for keyboard */
 
+    /* The input proxy sender is a client of the evdev driver and has an active
+     * grab. By default, Linux will send the LED events back to us, even if we
+     * sent them. This causes the events to recirculate forever, consuming lots
+     * of CPU and rendering the input device unusable. Avoid this issue by
+     * requesting Linux to not send LED events to us.
+     */
     if (ignore_led_events(fd) == -1)
         return 1;
 


### PR DESCRIPTION
This is a quick and minor follow-up to pull request https://github.com/QubesOS/qubes-app-linux-input-proxy/pull/32 . The commit addresses a [code review comment](https://github.com/QubesOS/qubes-app-linux-input-proxy/pull/32#pullrequestreview-2178906525) about adding a comment in the code, explaining the rationale for masking the LED events in `input-proxy-sender`.

Thank you,

Vefa