### PR TITLE
Add ability to filter qubes input devices with udev rules

### DIFF
--- a/qubes-rpc/qubes-input-proxy.rules
+++ b/qubes-rpc/qubes-input-proxy.rules
@@ -8,6 +8,9 @@ ENV{ID_PATH}=="platform-*", GOTO="qubes_input_proxy_end"
 # tag virtual input device so it can be identified when qubes-input-trigger is launched by /etc/xdg/autostart/qubes-input-trigger.desktop
 ATTRS{name}=="Qubes Virtual Input Device", TAG="qubes-virtual-input-device"
 
+# skip devices which are disabled for libignore
+ENV{LIBINPUT_IGNORE_DEVICE}=="1", GOTO="qubes_input_proxy_end"
+
 # skip virtual input device created by gui agent
 ATTRS{name}=="Qubes Virtual Input Device", GOTO="qubes_input_proxy_end"
 


### PR DESCRIPTION
I don't know how common this issue is, but on my system with sys-usb and *ask* for keyboard forwarding, I get a lot of unwanted keyboard proxy requests. In my case this includes the "keyboard" on my mouse, my fido2 device, my actual keyboard (which for some reason generates 3 extra forward requests), and for some reason my sound card.

This pull request allows users to write filters for their input devices, without simply blocking the device.