### PR TITLE
Handle additional PCIe bus address for QEMU emulated tablet

### DIFF
--- a/qubes-rpc/qubes-input-trigger
+++ b/qubes-rpc/qubes-input-trigger
@@ -117,6 +117,7 @@ def handle_event(input_dev, action, dom0):
                 # QEMU version, the device may look different. But it will
                 # always be the first bus, either on 00:04.0 or 00:05.0.
                 if udevreturn.get('ID_PATH') in (
+                        'pci-0000:00:03.0-usb-0:1:1.0',
                         'pci-0000:00:04.0-usb-0:1:1.0',
                         'pci-0000:00:05.0-usb-0:1:1.0') and \
                         udevreturn.get('ID_SERIAL', '').startswith('QEMU_QEMU_USB_Tablet'):


### PR DESCRIPTION
When the video-model feature is set to none, the lack of the presence of the VGA adapter changes the PCI address of the USB tablet. This causes it to be erroneously included in qubes-input-sender and attempt to make calls to dom0. This patch handles this case.