### PR TITLE
Add device info to qrexec call argument

### DIFF
--- a/debian/qubes-input-proxy-sender.install
+++ b/debian/qubes-input-proxy-sender.install
@@ -8,3 +8,4 @@
 /usr/lib/systemd/system/qubes-input-sender-mouse@.service
 /usr/lib/systemd/system/qubes-input-sender-keyboard@.service
 /usr/lib/systemd/system/qubes-input-sender-keyboard-mouse@.service
+/usr/lib/qubes/input-proxy-arg

--- a/qubes-rpc/Makefile
+++ b/qubes-rpc/Makefile
@@ -26,6 +26,8 @@ install-vm:
 		$(DESTDIR)$(USRLIBDIR)/udev/rules.d/90-qubes-uinput.rules
 	install -m 0644 -D qubes-uinput.modules \
 		$(DESTDIR)$(USRLIBDIR)/modules-load.d/qubes-uinput.conf
+	install -m 0755 -D input-proxy-arg \
+		$(DESTDIR)$(USRLIBDIR)/qubes/input-proxy-arg
 	install -d $(DESTDIR)/etc/qubes-rpc
 	install qubes.InputMouse $(DESTDIR)/etc/qubes-rpc
 	install qubes.InputKeyboard $(DESTDIR)/etc/qubes-rpc

--- a/qubes-rpc/input-proxy-arg
+++ b/qubes-rpc/input-proxy-arg
@@ -1,0 +1,28 @@
+#!/bin/bash
+
+dev="$1"
+output="$2"
+
+sysfs_path="/sys/class/input/${dev##*/}/device/uevent"
+
+[ -e "$sysfs_path" ] || exit
+product="$(grep ^PRODUCT= "$sysfs_path")"
+[ -n "$product" ] || exit
+product="${product#*=\"}"
+product="${product//\//-}"
+
+# by default include also physical port, but allow opt-out
+if ! [ -e /run/qubes-service/input-proxy-exclude-port ]; then
+    port="$(grep ^PHYS= "$sysfs_path")"
+    [ -n "$port" ] || exit
+    port="${port#*=\"}"
+    port="${port%/*}"
+    port="${port//:/_}"
+    # separate port from device with '-'
+    port="${port}-"
+else
+    port=
+fi
+
+mkdir -p "${output%/*}"
+echo "QREXEC_ARG=+$port$product" > "$output"

--- a/qubes-rpc/qubes-input-sender-keyboard-mouse@.service
+++ b/qubes-rpc/qubes-input-sender-keyboard-mouse@.service
@@ -6,4 +6,8 @@ OnFailure=qubes-input-sender-mouse@%i.service
 [Service]
 Environment=TARGET_DOMAIN=dom0
 EnvironmentFile=-/etc/qubes/input-proxy-target
-ExecStart=/usr/bin/qubes-input-sender qubes.InputKeyboard /dev/input/%i "$TARGET_DOMAIN"
+EnvironmentFile=-%t/qubes-input-proxy-env/%i
+ExecStartPre=/usr/lib/qubes/input-proxy-arg /dev/input/%i %t/qubes-input-proxy-env/%i
+ExecStart=/usr/bin/qubes-input-sender qubes.InputKeyboard${QREXEC_ARG} /dev/input/%i "$TARGET_DOMAIN"
+ExecStopPost=/bin/rm -f %t/qubes-input-proxy-env/%i
+PrivateTmp=yes

--- a/qubes-rpc/qubes-input-sender-keyboard@.service
+++ b/qubes-rpc/qubes-input-sender-keyboard@.service
@@ -5,4 +5,8 @@ After=qubes-qrexec-agent.service
 [Service]
 Environment=TARGET_DOMAIN=dom0
 EnvironmentFile=-/etc/qubes/input-proxy-target
-ExecStart=/usr/bin/qubes-input-sender qubes.InputKeyboard /dev/input/%i "$TARGET_DOMAIN"
+EnvironmentFile=-%t/qubes-input-proxy-env/%i
+ExecStartPre=/usr/lib/qubes/input-proxy-arg /dev/input/%i %t/qubes-input-proxy-env/%i
+ExecStart=/usr/bin/qubes-input-sender qubes.InputKeyboard${QREXEC_ARG} /dev/input/%i "$TARGET_DOMAIN"
+ExecStopPost=/bin/rm -f %t/qubes-input-proxy-env/%i
+PrivateTmp=yes

--- a/qubes-rpc/qubes-input-sender-mouse@.service
+++ b/qubes-rpc/qubes-input-sender-mouse@.service
@@ -5,4 +5,8 @@ After=qubes-qrexec-agent.service
 [Service]
 Environment=TARGET_DOMAIN=dom0
 EnvironmentFile=-/etc/qubes/input-proxy-target
-ExecStart=/usr/bin/qubes-input-sender qubes.InputMouse /dev/input/%i "$TARGET_DOMAIN"
+EnvironmentFile=-%t/qubes-input-proxy-env/%i
+ExecStartPre=/usr/lib/qubes/input-proxy-arg /dev/input/%i %t/qubes-input-proxy-env/%i
+ExecStart=/usr/bin/qubes-input-sender qubes.InputMouse${QREXEC_ARG} /dev/input/%i "$TARGET_DOMAIN"
+ExecStopPost=/bin/rm -f %t/qubes-input-proxy-env/%i
+PrivateTmp=yes

--- a/qubes-rpc/qubes-input-sender-tablet@.service
+++ b/qubes-rpc/qubes-input-sender-tablet@.service
@@ -5,4 +5,8 @@ After=qubes-qrexec-agent.service
 [Service]
 Environment=TARGET_DOMAIN=dom0
 EnvironmentFile=-/etc/qubes/input-proxy-target
-ExecStart=/usr/bin/qubes-input-sender qubes.InputTablet /dev/input/%i "$TARGET_DOMAIN"
+EnvironmentFile=-%t/qubes-input-proxy-env/%i
+ExecStartPre=/usr/lib/qubes/input-proxy-arg /dev/input/%i %t/qubes-input-proxy-env/%i
+ExecStart=/usr/bin/qubes-input-sender qubes.InputTablet${QREXEC_ARG} /dev/input/%i "$TARGET_DOMAIN"
+ExecStopPost=/bin/rm -f %t/qubes-input-proxy-env/%i
+PrivateTmp=yes

--- a/rpm_spec/input-proxy.spec.in
+++ b/rpm_spec/input-proxy.spec.in
@@ -85,6 +85,7 @@ rm -rf %{buildroot}/etc/qubes-rpc/policy
 /usr/bin/qubes-input-trigger
 %config(noreplace) /etc/xdg/autostart/qubes-input-trigger.desktop
 /usr/lib/udev/rules.d/90-qubes-input-proxy.rules
+/usr/lib/qubes/input-proxy-arg
 %{_unitdir}/qubes-input-sender-tablet@.service
 %{_unitdir}/qubes-input-sender-mouse@.service
 %{_unitdir}/qubes-input-sender-keyboard@.service


### PR DESCRIPTION
This allows setting policy for individual devices, not only device
types. It relies on USB qube (or wherever the device is connected)
giving accurate device info, but since it's going to be granted at least
partial control it needs to be trusted to some degree anyway.

Build the device info based on type/vendor/product/revision (the PRODUCT
property) and physical location (USB controller + port in case of USB
device). The latter can be disabled, to build a policy that allows
given device in any port.

Fixes QubesOS/qubes-issues#3604