### PR TITLE
Add device serial to qrexec call argument

### DIFF
--- a/qubes-rpc/input-proxy-arg
+++ b/qubes-rpc/input-proxy-arg
@@ -25,5 +25,18 @@ else
     port=
 fi
 
+uniq="$(grep ^UNIQ= "$sysfs_path")"
+# include serial, if present, but allow opt-out
+if [ -n "$uniq" ] && ! [ -e /run/qubes-service/input-proxy-exclude-serial ]; then
+    uniq="${uniq#*=}"
+    uniq="${uniq//\"/}"
+    uniq="${uniq%/*}"
+    uniq="${uniq//:/_}"
+    # separate serial from device with '+'
+    uniq="+${uniq}"
+else
+    uniq=
+fi
+
 mkdir -p "${output%/*}"
-echo "QREXEC_ARG=+$port$product" > "$output"
+echo "QREXEC_ARG=+$port$product$uniq" > "$output"


### PR DESCRIPTION
Some devices (especially high-assurance Common Criteria peripherals) present a serial number in the device descriptor to prevent substitution. This patch appends the device serial to the qrexec call argument, if it's present. It can also be opted out of with the input-proxy-exclude-serial feature.
